### PR TITLE
Add Forgot/Reset functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ Make sure you have [Node.js](https://nodejs.org/) and [MongoDB](https://www.mong
    ```plaintext
    MONGO_URI=your_mongodb_connection_string
    JWT_SECRET=your_jwt_secret
+
+   EMAIL_USER=your_email@gmail.com
+   EMAIL_PASS=your_email_password
+   JWT_RESET_SECRET=your_jwt_reset_secret
+
+   FRONTEND_URL=http://localhost:3000
    ```
 
 4. **Install frontend dependencies**:

--- a/backend/Controllers/passwordController.js
+++ b/backend/Controllers/passwordController.js
@@ -1,0 +1,57 @@
+import User from '../models/User.js'
+import jwt from 'jsonwebtoken'
+import bcrypt from 'bcryptjs'
+import nodemailer from 'nodemailer'
+import { sendResetEmail } from '../utils/sendEmail.js'
+
+const CLIENT_URL = 'http://localhost:3000' // Update if using frontend
+
+
+// Forgot Password
+export const forgotPassword = async (req, res) => {
+  const { email } = req.body
+
+  try {
+    const user = await User.findOne({ email })
+    if (!user) return res.status(404).json({ message: 'User not found' })
+
+    const token = jwt.sign(
+      { userId: user._id },
+      process.env.JWT_RESET_SECRET,
+      { expiresIn: '15m' }
+    )
+
+    const resetLink = `${process.env.FRONTEND_URL}/reset-password/${token}`
+
+    await sendResetEmail(user.email, resetLink)
+
+    res.status(200).json({ message: 'Password reset link sent to your email' })
+  } catch (err) {
+    console.error(err)
+    res.status(500).json({ message: 'Something went wrong. Try again.' })
+  }
+}
+
+// Reset Password
+export const resetPassword = async (req, res) => {
+  const { token, newPassword } = req.body
+
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_RESET_SECRET)
+
+    const user = await User.findById(decoded.userId)
+    if (!user) return res.status(404).json({ message: 'User not found' })
+
+    const hashedPassword = await bcrypt.hash(newPassword, 10)
+    user.password = hashedPassword
+    await user.save()
+
+    res.status(200).json({ message: 'Password reset successful' })
+  } catch (err) {
+    console.error(err)
+    if (err.name === 'TokenExpiredError') {
+      return res.status(400).json({ message: 'Reset link expired. Please request again.' })
+    }
+    res.status(500).json({ message: 'Invalid or expired token.' })
+  }
+}

--- a/backend/index.js
+++ b/backend/index.js
@@ -13,8 +13,10 @@ dotenv.config()
 const app = express()
 const port = process.env.PORT || 8000
 const corsOptions = {
-   origin: true,
-   credentials: true
+   origin: 'http://localhost:3000',
+   credentials: true,
+   methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+   allowedHeaders: ['Content-Type', 'Authorization']
 }
 
 mongoose.set("strictQuery", false)

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -1,5 +1,6 @@
 import express from 'express'
 import { login, register } from '../Controllers/authController.js'
+import { forgotPassword, resetPassword } from '../Controllers/passwordController.js'
 // import bcrypt from 'bcryptjs'
 // import jwt from 'jsonwebtoken'
 
@@ -7,6 +8,9 @@ const router = express.Router()
 
 router.post('/register', register)
 router.post('/login', login)
+
+router.post('/forgot-password', forgotPassword)
+router.post('/reset-password', resetPassword)
 
 
 export default router

--- a/backend/utils/sendEmail.js
+++ b/backend/utils/sendEmail.js
@@ -1,0 +1,24 @@
+import nodemailer from 'nodemailer'
+import dotenv from 'dotenv'
+dotenv.config()
+
+const transporter = nodemailer.createTransport({
+  service: 'gmail',
+  auth: {
+    user: process.env.EMAIL_USER,
+    pass: process.env.EMAIL_PASS,
+  },
+})
+
+export const sendResetEmail = async (email, resetLink) => {
+  await transporter.sendMail({
+    from: `"Support" <${process.env.EMAIL_USER}>`,
+    to: email,
+    subject: 'Password Reset Request',
+    html: `
+      <p>You requested a password reset.</p>
+      <p>Click <a href="${resetLink}">here</a> to reset your password.</p>
+      <p>This link will expire in 15 minutes.</p>
+    `,
+  })
+}

--- a/frontend/src/components/Footer/Footer.jsx
+++ b/frontend/src/components/Footer/Footer.jsx
@@ -33,6 +33,10 @@ const quick__links2 = [
       path: '/register',
       display: 'Register'
    },
+   {
+      path: '/reset-password',
+      display: 'Reset Password'
+   }
 ]
 
 const Footer = () => {

--- a/frontend/src/pages/ForgotPassword.jsx
+++ b/frontend/src/pages/ForgotPassword.jsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react'
+import { Container, Row, Col, Form, FormGroup, Button } from 'reactstrap'
+import '../styles/login.css'
+import { BASE_URL } from '../utils/config'
+import { useNavigate } from 'react-router-dom'
+
+const ForgotPassword = () => {
+   const [email, setEmail] = useState('')
+   const [message, setMessage] = useState('')
+   const navigate = useNavigate()
+
+   const handleSubmit = async e => {
+      e.preventDefault()
+
+      try {
+         const res = await fetch(`${BASE_URL}/auth/forgot-password`, {
+            method: 'POST',
+            headers: {
+               'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ email }),
+         })
+
+         const result = await res.json()
+         setMessage(result.message)
+      } catch (err) {
+         setMessage('Something went wrong. Try again.')
+      }
+   }
+
+   return (
+      <section style={{ backgroundColor: 'black' }}>
+         <Container>
+            <Row>
+               <Col lg='6' className='m-auto'>
+                  <div className='login__form'>
+                     <h2>Forgot Password</h2>
+                     <Form onSubmit={handleSubmit}>
+                        <FormGroup>
+                           <input
+                              type='email'
+                              placeholder='Enter your registered email'
+                              value={email}
+                              onChange={(e) => setEmail(e.target.value)}
+                              required
+                           />
+                        </FormGroup>
+                        <Button className='btn secondary__btn auth__btn' type='submit'>
+                           Send Reset Link
+                        </Button>
+                     </Form>
+                     {message && <p style={{ color: 'white', marginTop: '1rem' }}>{message}</p>}
+                  </div>
+               </Col>
+            </Row>
+         </Container>
+      </section>
+   )
+}
+
+export default ForgotPassword

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -103,6 +103,7 @@ const Login = () => {
                     Login
                   </Button>
                 </Form>
+                <p><link to="/forgot-password">Forgot Password?</link></p>
                 <p>
                   Don't have an account? <Link to="/register">Create</Link>
                 </p>

--- a/frontend/src/pages/ResetPassword.jsx
+++ b/frontend/src/pages/ResetPassword.jsx
@@ -1,0 +1,67 @@
+import React, { useState } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { Container, Row, Col, Form, FormGroup, Button } from 'reactstrap'
+import '../styles/login.css'
+import { BASE_URL } from '../utils/config'
+
+const ResetPassword = () => {
+   const { token } = useParams()
+   const [newPassword, setNewPassword] = useState('')
+   const [message, setMessage] = useState('')
+   const navigate = useNavigate()
+
+   const handleSubmit = async e => {
+      e.preventDefault()
+
+      try {
+         const res = await fetch(`${BASE_URL}/auth/reset-password`, {
+            method: 'POST',
+            headers: {
+               'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ token, newPassword }),
+         })
+
+         const result = await res.json()
+         if (res.ok) {
+            setMessage(result.message)
+            setTimeout(() => navigate('/login'), 2000)
+         } else {
+            setMessage(result.message || 'Error resetting password.')
+         }
+      } catch (err) {
+         setMessage('Something went wrong.')
+      }
+   }
+
+   return (
+      <section style={{ backgroundColor: 'black' }}>
+         <Container>
+            <Row>
+               <Col lg='6' className='m-auto'>
+                  <div className='login__form'>
+                     <h2>Reset Password</h2>
+                     <Form onSubmit={handleSubmit}>
+                        <FormGroup>
+                           <input
+                              type='password'
+                              placeholder='Enter new password'
+                              value={newPassword}
+                              onChange={(e) => setNewPassword(e.target.value)}
+                              required
+                           />
+                        </FormGroup>
+                        <Button className='btn secondary__btn auth__btn' type='submit'>
+                           Reset Password
+                        </Button>
+                     </Form>
+                     {message && <p style={{ color: 'white', marginTop: '1rem' }}>{message}</p>}
+                  </div>
+               </Col>
+            </Row>
+         </Container>
+      </section>
+   )
+}
+
+export default ResetPassword

--- a/frontend/src/router/Routers.js
+++ b/frontend/src/router/Routers.js
@@ -7,6 +7,8 @@ import Register from './../pages/Register'
 import SearchResultList from './../pages/SearchResultList'
 import TourDetails from './../pages/TourDetails'
 import Tours from './../pages/Tours'
+import ForgotPassword from '../pages/ForgotPassword'
+import ResetPassword from '../pages/ResetPassword'
 
 const Routers = () => {
    return (
@@ -19,6 +21,8 @@ const Routers = () => {
          <Route path='/register' element={<Register/>} />
          <Route path='/thank-you' element={<ThankYou/>} />
          <Route path='/tours/search' element={<SearchResultList/>} />
+         <Route path='/forgot-password' element={<ForgotPassword/>} />
+         <Route path='/reset-password/:token' element={<ResetPassword/>} />
       </Routes>
    )
 }


### PR DESCRIPTION
This PR closes issue #5 
- I have added Reset password functionality along with forgot password functionality
- Created new files for frontend and backend where needed
- updated the "read me" file's .env section
- Tested the results locally (using postman)
<img width="600" height="500" alt="Screenshot 2025-07-31 223745" src="https://github.com/user-attachments/assets/17b34ec0-73df-43d4-ad29-8b3bce4a397b" />
<img width="600" height="500" alt="Screenshot 2025-07-31 231038" src="https://github.com/user-attachments/assets/eceeeed1-36cc-4bb8-880c-8902895fb3c1" />

I have added a "Reset password link in the footer section" which can be changed to personal profile page when the page is ready.
<img width="300" height="200" alt="Screenshot 2025-07-31 232424" src="https://github.com/user-attachments/assets/1a0893e6-3fe4-401b-acba-6c9609cd114e" />

@adityakalburgi please review this.
